### PR TITLE
Ruby2.5 is no longer supported

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,8 @@
 require: rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5
-  Exclude:
-    - 'speedtest_net.gemspec'
-
-Layout/ClassStructure:
-  Enabled: true
+  TargetRubyVersion: 2.6
+  NewCops: enable
 
 Style/Documentation:
   Enabled: false

--- a/speedtest_net.gemspec
+++ b/speedtest_net.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.add_dependency 'curb', '~> 0.9'
   spec.add_dependency 'rexml', '~> 3.2'


### PR DESCRIPTION
- Changed Ruby version requirement from 2.5 to 2.6
- Enable all rubocop cops
